### PR TITLE
Fixes for dependents on the pure CMake packages

### DIFF
--- a/mesh_segmenter/colcon.pkg
+++ b/mesh_segmenter/colcon.pkg
@@ -1,0 +1,3 @@
+{
+    "hooks": ["share/mesh_segmenter/hook/ament_prefix_path.dsv", "share/mesh_segmenter/hook/ros_package_path.dsv"]
+}

--- a/mesh_segmenter/package.xml
+++ b/mesh_segmenter/package.xml
@@ -3,11 +3,15 @@
   <name>mesh_segmenter</name>
   <version>0.0.0</version>
   <description>The mesh_segmenter package</description>
- <maintainer email="jrgnichodevel@gmail.com">Jorge Nicho</maintainer>
- <maintainer email="colin.lewis@swri.org">Colin Lewis</maintainer>
+  <maintainer email="jrgnichodevel@gmail.com">Jorge Nicho</maintainer>
+  <maintainer email="colin.lewis@swri.org">Colin Lewis</maintainer>
   <license>Apache 2.0</license>
 
   <build_depend>ros_industrial_cmake_boilerplate</build_depend>
   <depend>vtk_viewer</depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
 
 </package>

--- a/path_sequence_planner/colcon.pkg
+++ b/path_sequence_planner/colcon.pkg
@@ -1,0 +1,3 @@
+{
+    "hooks": ["share/path_sequence_planner/hook/ament_prefix_path.dsv", "share/path_sequence_planner/hook/ros_package_path.dsv"]
+}

--- a/path_sequence_planner/package.xml
+++ b/path_sequence_planner/package.xml
@@ -3,11 +3,15 @@
   <name>path_sequence_planner</name>
   <version>0.0.0</version>
   <description>The path_sequence_planner package</description>
- <maintainer email="jrgnichodevel@gmail.com">Jorge Nicho</maintainer>
+  <maintainer email="jrgnichodevel@gmail.com">Jorge Nicho</maintainer>
   <license>Apache 2.0</license>
 
+  <build_depend>ros_industrial_cmake_boilerplate</build_depend>
   <depend>vtk_viewer</depend>
   <depend>tool_path_planner</depend>
-  <build_depend>ros_industrial_cmake_boilerplate</build_depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
 
 </package>

--- a/tool_path_planner/colcon.pkg
+++ b/tool_path_planner/colcon.pkg
@@ -1,0 +1,3 @@
+{
+    "hooks": ["share/tool_path_planner/hook/ament_prefix_path.dsv", "share/tool_path_planner/hook/ros_package_path.dsv"]
+}

--- a/tool_path_planner/package.xml
+++ b/tool_path_planner/package.xml
@@ -3,7 +3,7 @@
   <name>tool_path_planner</name>
   <version>0.0.0</version>
   <description>The path_planner package</description>
- <maintainer email="jrgnichodevel@gmail.com">Jorge Nicho</maintainer>
+  <maintainer email="jrgnichodevel@gmail.com">Jorge Nicho</maintainer>
   <license>Apache 2.0</license>
 
   <build_depend>cmake_modules</build_depend>
@@ -11,5 +11,9 @@
   <depend>vtk_viewer</depend>
   <depend>libpcl-all-dev</depend>
   <depend>libjsoncpp-dev</depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
 
 </package>

--- a/vtk_viewer/colcon.pkg
+++ b/vtk_viewer/colcon.pkg
@@ -1,0 +1,3 @@
+{
+    "hooks": ["share/vtk_viewer/hook/ament_prefix_path.dsv", "share/vtk_viewer/hook/ros_package_path.dsv"]
+}

--- a/vtk_viewer/package.xml
+++ b/vtk_viewer/package.xml
@@ -6,15 +6,14 @@
  <maintainer email="jrgnichodevel@gmail.com">Jorge Nicho</maintainer>
   <license>Apache 2.0</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
   <build_depend>ros_industrial_cmake_boilerplate</build_depend>
   <depend>libconsole-bridge-dev</depend>
   <depend>libpcl-all-dev</depend>
 
   <test_depend>rosunit</test_depend>
-  
+
   <export>
-	  <build_type> cmake </build_type>
+    <build_type>cmake</build_type>
   </export>
 
 </package>


### PR DESCRIPTION
Without these, packages that depend on the pure CMake packages can't find them if they're build in a non-merged install space via colcon.